### PR TITLE
docs: fix duplicated word in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Clone the repository.
 git clone https://github.com/sesto-dev/next-prisma-tailwind-ecommerce
 ```
 
-Navigate to each folder in the `apps` folder and and set the variables.
+Navigate to each folder in the `apps` folder and set the variables.
 
 ```sh
 cp .env.example .env


### PR DESCRIPTION
## Summary
- fix duplicated 'and' in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844a7e14994832abe6642256e3a4656