### PR TITLE
Implement RNG OTP and minor fixes

### DIFF
--- a/apps/admin/src/actions/get-total-revenue.ts
+++ b/apps/admin/src/actions/get-total-revenue.ts
@@ -1,25 +1,10 @@
 import prisma from '@/lib/prisma'
 
 export const getTotalRevenue = async () => {
-   const paidOrders = await prisma.order.findMany({
-      where: {
-         isPaid: true,
-      },
-      include: {
-         orderItems: {
-            include: {
-               product: { include: { categories: true } },
-            },
-         },
-      },
+   const revenue = await prisma.orderItem.aggregate({
+      _sum: { price: true },
+      where: { order: { isPaid: true } },
    })
 
-   const totalRevenue = paidOrders.reduce((total, order) => {
-      const orderTotal = order.orderItems.reduce((orderSum, item) => {
-         return orderSum + item.price
-      }, 0)
-      return total + orderTotal
-   }, 0)
-
-   return totalRevenue
+   return revenue._sum.price ?? 0
 }

--- a/apps/admin/src/app/api/auth/otp/email/try/route.ts
+++ b/apps/admin/src/app/api/auth/otp/email/try/route.ts
@@ -1,7 +1,7 @@
 import config from '@/config/site'
 import Mail from '@/emails/verify'
 import prisma from '@/lib/prisma'
-import { generateSerial } from '@/lib/serial'
+import { generateOTP } from '@persepolis/rng'
 import { getErrorResponse } from '@/lib/utils'
 import { sendMail } from '@persepolis/mail'
 import { isEmailValid } from '@persepolis/regex'
@@ -11,7 +11,7 @@ import { ZodError } from 'zod'
 
 export async function POST(req: NextRequest) {
    try {
-      const OTP = generateSerial({})
+      const OTP = generateOTP()
 
       const { email } = await req.json()
 

--- a/apps/storefront/src/app/api/auth/otp/email/try/route.ts
+++ b/apps/storefront/src/app/api/auth/otp/email/try/route.ts
@@ -1,7 +1,7 @@
 import config from '@/config/site'
 import Mail from '@/emails/verify'
 import prisma from '@/lib/prisma'
-import { generateSerial } from '@/lib/serial'
+import { generateOTP } from '@persepolis/rng'
 import { getErrorResponse } from '@/lib/utils'
 import { sendMail } from '@persepolis/mail'
 import { isEmailValid } from '@persepolis/regex'
@@ -11,7 +11,7 @@ import { ZodError } from 'zod'
 
 export async function POST(req: NextRequest) {
    try {
-      const OTP = generateSerial({})
+      const OTP = generateOTP()
 
       const { email } = await req.json()
 

--- a/apps/storefront/src/app/api/auth/otp/phone/try/route.ts
+++ b/apps/storefront/src/app/api/auth/otp/phone/try/route.ts
@@ -1,5 +1,5 @@
 import prisma from '@/lib/prisma'
-import { generateSerial } from '@/lib/serial'
+import { generateOTP } from '@persepolis/rng'
 import { getErrorResponse } from '@/lib/utils'
 import { isIranianPhoneNumberValid } from '@persepolis/regex'
 import { sendTransactionalSMS } from '@persepolis/sms'
@@ -8,7 +8,7 @@ import { ZodError } from 'zod'
 
 export async function POST(req: NextRequest) {
    try {
-      const OTP = generateSerial({})
+      const OTP = generateOTP()
 
       const { phone } = await req.json()
 

--- a/apps/storefront/src/hooks/useAuthentication.tsx
+++ b/apps/storefront/src/hooks/useAuthentication.tsx
@@ -9,13 +9,15 @@ export function useAuthenticated() {
    useEffect(() => {
       try {
          if (typeof window !== 'undefined' && window.localStorage) {
-            const cookies = document.cookie.split(';')
-            const loggedInCookie =
-               cookies
-                  .find((cookie) => cookie.startsWith('logged-in'))
-                  .split('=')[1] === 'true'
-
-            setAuthenticated(loggedInCookie ?? false)
+            const cookies = Object.fromEntries(
+               document.cookie
+                  .split('; ')
+                  .map((c) => {
+                     const [k, v] = c.split('=')
+                     return [k, v]
+                  })
+            )
+            setAuthenticated(cookies['logged-in'] === 'true')
          }
       } catch (error) {
          console.error({ error })

--- a/apps/storefront/src/lib/omit.ts
+++ b/apps/storefront/src/lib/omit.ts
@@ -1,9 +1,10 @@
-export function omitUser<User, Key extends keyof User>(
+export function omitUser<User extends Record<string, any>, Key extends keyof User>(
    user: User,
    ...keys: Key[]
 ): Omit<User, Key> {
-   for (let key of keys) {
-      delete user['password']
+   const clone = { ...user }
+   for (const key of keys) {
+      delete clone[key]
    }
-   return user
+   return clone
 }

--- a/packages/oauth/src/apple.ts
+++ b/packages/oauth/src/apple.ts
@@ -1,10 +1,12 @@
+import { randomUUID } from 'crypto'
+
 const teamID = process.env.NEXT_PUBLIC_APPLE_TEAM_ID
 const clientID = process.env.NEXT_PUBLIC_APPLE_CLIENT_ID
 const redirectURI = process.env.NEXT_PUBLIC_URL + "/callback/apple"
-const state = "RANDOMLY_GENERATED_STATE"
 const clientSecret = process.env.APPLE_CLIENT_SECRET
 
 export function getAppleSignInURL() {
+  const state = randomUUID()
   return `https://appleid.apple.com/auth/authorize?response_type=code&client_id=${clientID}&redirect_uri=${redirectURI}&state=${state}&scope=name%20email`
 }
 

--- a/packages/rng/package.json
+++ b/packages/rng/package.json
@@ -25,6 +25,7 @@
    },
    "homepage": "https://github.com/sesto-dev/next-prisma-tailwind-ecommerce#readme",
    "devDependencies": {
+      "@types/node": "^22.15.30",
       "typescript": "^5.2.2"
    },
    "peerDependencies": {

--- a/packages/rng/src/index.ts
+++ b/packages/rng/src/index.ts
@@ -1,3 +1,4 @@
+import { randomInt } from "crypto"
 export function getRandomFloat(min, max, precision) {
    if (min >= max || precision < 0) {
       throw new Error(
@@ -123,4 +124,12 @@ export function getRandomIndexFromArrayExcept(
    }
 
    return randomIndex
+}
+
+export function generateOTP(length: number = 6): string {
+   let otp = ''
+   for (let i = 0; i < length; i++) {
+      otp += randomInt(0, 10).toString()
+   }
+   return otp
 }

--- a/packages/rng/yarn.lock
+++ b/packages/rng/yarn.lock
@@ -2,12 +2,19 @@
 # yarn lockfile v1
 
 
-"@types/node@^20.6.2":
-  version "20.6.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.6.4.tgz#7882cb8b8adc3106c352dac9c02d4d3ebb95cf3e"
-  integrity sha512-nU6d9MPY0NBUMiE/nXd2IIoC4OLvsLpwAjheoAeuzgvDZA1Cb10QYg+91AF6zQiKWRN5i1m07x6sMe0niBznoQ==
+"@types/node@^22.15.30":
+  version "22.15.30"
+  resolved "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz"
+  integrity sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==
+  dependencies:
+    undici-types "~6.21.0"
 
 typescript@^5.2.2:
   version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==


### PR DESCRIPTION
## Summary
- add secure OTP generator in rng package
- use OTP generator in email/phone routes
- update Apple OAuth to randomize state
- optimize revenue query with Prisma aggregate
- improve cookie parsing and omit helper

## Testing
- `npm run build` in `packages/rng`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b2e0c328832a882a58d74827b181